### PR TITLE
Fix network config transfer issue and update for 1.19 goats

### DIFF
--- a/resources/assets/animalcages/config/defaultconfig.json
+++ b/resources/assets/animalcages/config/defaultconfig.json
@@ -303,6 +303,94 @@
         {
             "name": "wildturkey-hen",
             "scale": 1.0
+        },
+        {
+          "name": "goat-angora-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-angora-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexalp-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexalp-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexnub-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexnub-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-markhor-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-markhor-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-mountain-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-mountain-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-muskox-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-muskox-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-nubian-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-nubian-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-sirohi-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-sirohi-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-takingold-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-takingold-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-turdag-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-turdag-female-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-valais-male-baby",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-valais-female-baby",
+          "scale": 1.0
         }
     ],
     "mediumCatchableEntities": [
@@ -469,6 +557,94 @@
         {
             "name": "gazelle-male",
             "scale": 1.0
+        },
+        {
+          "name": "goat-angora-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-angora-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexalp-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexalp-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexnub-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-ibexnub-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-markhor-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-markhor-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-mountain-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-mountain-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-muskox-male-adult",
+          "scale": 0.9
+        },
+        {
+          "name": "goat-muskox-female-adult",
+          "scale": 0.9
+        },
+        {
+          "name": "goat-nubian-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-nubian-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-sirohi-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-sirohi-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-takingold-male-adult",
+          "scale": 0.9
+        },
+        {
+          "name": "goat-takingold-female-adult",
+          "scale": 0.9
+        },
+        {
+          "name": "goat-turdag-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-turdag-female-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-valais-male-adult",
+          "scale": 1.0
+        },
+        {
+          "name": "goat-valais-female-adult",
+          "scale": 1.0
         }
     ],
     "woundedMultiplicator": 3

--- a/src/AnimalCages.cs
+++ b/src/AnimalCages.cs
@@ -15,15 +15,15 @@ namespace Animalcages
             api.RegisterBlockClass("blockmediumanimalcage", typeof(BlockMediumCage));
             api.RegisterBlockEntityClass("blockentitysmallanimalcage", typeof(BlockEntityAnimalCage));
             api.RegisterBlockEntityClass("blockentitymediumanimalcage", typeof(BlockEntityMediumAnimalCage));
+
+            api.Network.RegisterChannel("animalcagesnetwork").RegisterMessageType<CageConfig>();
         }
 
         public override void StartClientSide(ICoreClientAPI api)
         {
             base.StartClientSide(api);
 
-            api.Network
-                .RegisterChannel("animalcagesnetwork")
-                .RegisterMessageType<CageConfig>()
+            api.Network.GetChannel("animalcagesnetwork")
                 .SetMessageHandler<CageConfig>(packet => CageConfig.Current = packet);
         }
         public override void StartServerSide(ICoreServerAPI api)
@@ -59,14 +59,10 @@ namespace Animalcages
                 api.StoreModConfig(CageConfig.Current, "animalcagesconfig.json");
             }
 
-            api.Network
-                .RegisterChannel("animalcagesnetwork")
-                .RegisterMessageType<CageConfig>();
-
             api.Event.PlayerJoin += (byPlayer) =>
                 api.Network
                     .GetChannel("animalcagesnetwork")
-                    .BroadcastPacket<CageConfig>(CageConfig.Current, new IServerPlayer[] { byPlayer });
+                    .SendPacket<CageConfig>(CageConfig.Current, new IServerPlayer[] { byPlayer });
         }
     }
 


### PR DESCRIPTION

BroadcastPacket takes a list of players to EXCLUDE
SendPacket takes a list of players to INCLUDE
Excluing the joined player meant the player never received the server config which resulted in cages being invisible

Additionally no need to re-register the channel. Just do it once in the universal Start function.