### PR TITLE
Added support for config entity name that ends in asterisk

### DIFF
--- a/src/AnimalCages.cs
+++ b/src/AnimalCages.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using ProtoBuf;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -82,16 +83,49 @@ namespace Animalcages
 
         public float getScale(string entity)
         {
-            var find = smallCatchableEntities.Find(x => x.name == entity);
+            var find = GetSmallCatchableEntity(entity);
             if (find != null) { return find.scale; }
 
-            find = mediumCatchableEntities.Find(x => x.name == entity);
+            find = GetMediumCatchableEntity(entity);
             if (find != null) { return find.scale; }
 
             return 1f;
-
         }
-        
+
+        public CatchableEntity GetSmallCatchableEntity(string entity)
+        {
+            var find = smallCatchableEntities.Find((x) =>
+            {
+                if (x.name.EndsWith("*") && entity.StartsWith(x.name.Remove(x.name.Length - 1)))
+                {
+                    return true;
+                }
+                else if (x.name == entity)
+                {
+                    return true;
+                }
+                return false;
+            });
+            return find;
+        }
+
+        public CatchableEntity GetMediumCatchableEntity(string entity)
+        {
+            var find = mediumCatchableEntities.Find((x) =>
+            {
+                if (x.name.EndsWith("*") && entity.StartsWith(x.name.Remove(x.name.Length - 1)))
+                {
+                    return true;
+                }
+                else if (x.name == entity)
+                {
+                    return true;
+                }
+                return false;
+            });
+            return find;
+        }
+
         [ProtoContract(ImplicitFields = ImplicitFields.AllPublic)]
         public class CatchableEntity
         {

--- a/src/BlockMediumCage.cs
+++ b/src/BlockMediumCage.cs
@@ -62,8 +62,8 @@ namespace Animalcages
         }
         protected override bool isCatchable(Entity byEntity, Entity attackedEntity)
         {
-            bool mediumEntity = CageConfig.Current.mediumCatchableEntities.Exists(x => x.name == attackedEntity.Properties.Code.GetName());
-            bool smallEntity = CageConfig.Current.smallCatchableEntities.Exists(x => x.name == attackedEntity.Properties.Code.GetName());
+            bool mediumEntity = CageConfig.Current.GetMediumCatchableEntity(attackedEntity.Properties.Code.GetName()) != null;
+            bool smallEntity = CageConfig.Current.GetSmallCatchableEntity(attackedEntity.Properties.Code.GetName()) != null;
             int generation = attackedEntity.WatchedAttributes.GetInt("generation", 0);
             var bh = attackedEntity.GetBehavior<EntityBehaviorHealth>();
             bool wounded = bh.MaxHealth >= bh.Health * CageConfig.Current.woundedMultiplicator;

--- a/src/BlockSmallCage.cs
+++ b/src/BlockSmallCage.cs
@@ -56,7 +56,7 @@ namespace Animalcages
         }
         protected override bool isCatchable(Entity byEntity, Entity entity)
         {
-            return CageConfig.Current.smallCatchableEntities.Exists(x => x.name == entity.Properties.Code.GetName());
+            return CageConfig.Current.GetSmallCatchableEntity(entity.Properties.Code.GetName()) != null;
         }
     }
 }


### PR DESCRIPTION
Added functionality to be able to define config entities like for example "caninae-*" for those mods that add entities with multiple variations. I was thinking on implement something with regex but can be complex for final user so I choose for a simple * implementation