### PR TITLE
Update to Vintage Story v1.22-rc.5

### DIFF
--- a/animalcages.csproj
+++ b/animalcages.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -7,8 +7,8 @@
         "G3rste"
     ],
     "description": "Mod that adds cages for animals so you can catch, transport and display them.",
-    "version": "4.0.2",
+    "version": "5.0.0",
     "dependencies": {
-        "game": "1.21.0"
+        "game": "1.22.0-rc.5"
     }
 }

--- a/src/BlockEntityAnimalCage.cs
+++ b/src/BlockEntityAnimalCage.cs
@@ -27,7 +27,6 @@ namespace Animalcages
             if (entity != null)
             {
                 entity.Pos.SetPos(Pos);
-                entity.ServerPos.SetPos(Pos);
                 Api.World.SpawnEntity(entity);
             }
         }


### PR DESCRIPTION
This PR bumps the mod version to v5.0.0 and migrates the existing mod functionality to support Vintage Story v1.22-rc.5.

The only major changes made were to update the .NET runtime to version 10, as well as remove a redundant call to `entity.ServerPos.SetPos()` upon breaking a cage.
